### PR TITLE
Call parent constructor instead of repeating code

### DIFF
--- a/wp-content/plugins/rest-functions/src/Endpoints/HomePageController.php
+++ b/wp-content/plugins/rest-functions/src/Endpoints/HomePageController.php
@@ -13,8 +13,8 @@ class HomePageController extends \WP_REST_Posts_Controller {
     protected $post_type;
 
     public function __construct($post_type = 'page') {
+        parent::__construct($post_type);
         $this->namespace = $this->namespaceBase . '/' . $this->version;
-        $this->post_type = $post_type;
     }
 
     public function register_routes() {


### PR DESCRIPTION
fix from
https://github.com/viastudio/wp.mysterymanofmaryland.com/commit/1620b9c274b8d98ab9bad8087accc905a3170429