### PR TITLE
Perform `hub:build` task on `grunt setup`.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -97,5 +97,5 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-via-filesystem');
 
     grunt.registerTask('default', ['shell:theme_npm_install', 'shell:theme_bower_install', 'hub:build']); // Default task - executes when you run grunt
-    grunt.registerTask('setup', ['shell:wordpress_download', 'shell:theme_npm_install', 'shell:theme_bower_install', 'via_filesystem', 'shell:plugin_npm_install']);
+    grunt.registerTask('setup', ['shell:wordpress_download', 'shell:theme_npm_install', 'shell:theme_bower_install', 'via_filesystem', 'shell:plugin_npm_install', 'hub:build']);
 };


### PR DESCRIPTION
This is required to do the `composer install` for the WP REST plugin. Missing the plugin vendor files causes the wp plugin update script to fail.